### PR TITLE
Bump 'from' debian version 11.5-slim -> 11.6-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:11.5-slim
+FROM debian:11.6-slim
 
 ENV HOME="/root"
 WORKDIR $HOME


### PR DESCRIPTION
🐟 

Checking with:
```bash
make version=v7.1-debug build
make version=v7.1-debug deploy
```